### PR TITLE
USERコマンドの実装

### DIFF
--- a/includes/user.h
+++ b/includes/user.h
@@ -8,7 +8,6 @@ class Channel;
 
 class User : public EventListener{
 	public:
-		User();
 		User(int fd);
 		~User();
 		std::map<int, std::string> PassCommand(Event& event);
@@ -27,10 +26,14 @@ class User : public EventListener{
 	private:
 		int	fd_;
 		bool	is_password_authenticated_;
+		bool	is_user_done_;
 		std::string	nick_name_;
 		std::string	user_name_;
+		std::string	real_name_;
 		std::string server_password_;
 		std::vector<Channel>	channels_;
+
+		User(void);
 };
 
 #endif

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -1,15 +1,13 @@
 #include "user.h"
 #include "channel.h"
 
-User::User(){
+User::User() {
 }
 
-User::User(int fd) : fd_(fd), is_password_authenticated_(false){
-	(void)fd_;
-	(void)is_password_authenticated_;
+User::User(int fd) : fd_(fd), is_password_authenticated_(false), is_user_done_(false) {
 }
 
-User::~User(){
+User::~User() {
 }
 
 std::map<int, std::string> User::PassCommand(Event& event) {
@@ -43,12 +41,31 @@ std::map<int, std::string> User::NickCommand(Event& event){
 	return error_message;
 }
 
-std::map<int, std::string> User::UserCommand(Event& event){
-	(void)event;
-	std::map<int, std::string> error_message;
+std::map<int, std::string> User::UserCommand(Event& event) {
+	const int kParamsSize = 3;
+
+	std::map<int, std::string> ret_map;
+	std::vector<std::string> params = event.get_command_params();
+
 	std::cout << "User method called!" << std::endl;
-	utils::print_string_vector(event.get_command_params());
-	return error_message;
+
+	if (event.get_fd() != this->get_fd())
+		return ret_map;
+	if (params.size() < kParamsSize)
+		ret_map.insert(std::make_pair(this->get_fd(), "ERR_NEEDMOREPARAMS"));
+	else if (this->is_user_done_)
+		ret_map.insert(std::make_pair(this->get_fd(), "ERR_ALREADYREGISTRED"));
+	else {
+		this->is_user_done_ = true;
+		this->user_name_ = params[0];
+		// 今回は1,2番目の要素は無視する
+		for (int i = 3; i < params.size(); i++) {
+			if (i != 3)
+				this->real_name_ += " ";
+			this->real_name_ += params[i];
+		}
+	}
+	return ret_map;
 }
 
 std::map<int, std::string> User::JoinCommand(Event& event){


### PR DESCRIPTION
USERコマンドをとりあえずこれまでの形式(Eventクラスを引数に取り、戻り値をmapとする)に従った関数で実装しました。
それに伴い、Userクラスも少し変更を加えました。
変更内容: 
・デフォルトコンストラクタをprivateへ移動
・is_user_done_, real_name_ パラメータの追加
(getterとsetterを作り忘れましたが、Userクラスの他のメンバ変数たちもないみたいなので、あとでそれらとまとめて実装する、で良いと思いました。)