### PR TITLE
ADD #31-modify-event_lister to excecute command

### DIFF
--- a/includes/channel.h
+++ b/includes/channel.h
@@ -7,8 +7,10 @@ class User;
 
 class Channel: public EventListener{
 	public:
-		Channel();
 		~Channel();
+
+	private:
+		Channel();
 		std::map<int, std::string> PassCommand(Event& event);
 		std::map<int, std::string> NickCommand(Event& event);
 		std::map<int, std::string> UserCommand(Event& event);
@@ -19,7 +21,6 @@ class Channel: public EventListener{
 		std::map<int, std::string> ModeCommand(Event& event);
 		std::map<int, std::string> PrivmsgCommand(Event& event);
 
-	private:
 		std::vector<User>	users_;
 		std::string		topic_;
 		std::string		key_;

--- a/includes/event_handler.h
+++ b/includes/event_handler.h
@@ -28,8 +28,6 @@ class EventHandler{
 		void				Receive(Event event, char* buffer);
 		message::ParseState	Parse(const char *buffer, Event& event);
 		void				ExecuteCommand(Event event);
-		void				CallStartEventListener(Event& event);
-		void				CallEndEventListener(Event& event);
 		void				Send(Event event);
 		void				Detach(pollfd entry);
 		void				HandlePollInEvent(pollfd entry);

--- a/includes/event_listener.h
+++ b/includes/event_listener.h
@@ -1,15 +1,18 @@
 #ifndef EVENT_LISTENER_H_
  #define EVENT_LISTENER_H_
 
-
 #include "event.h"
 #include "utils.h"
+#include "message.h"
 
 class EventListener
 {
 	public:
 		EventListener();
 		virtual ~EventListener();
+		void ExecuteCommand(std::map<int, std::string>& response, Event& event);
+
+	private:
 		virtual std::map<int, std::string> PassCommand(Event& event) = 0;
 		virtual std::map<int, std::string> NickCommand(Event& event) = 0;
 		virtual std::map<int, std::string> UserCommand(Event& event) = 0;
@@ -19,8 +22,6 @@ class EventListener
 		virtual std::map<int, std::string> TopicCommand(Event& event) = 0;
 		virtual std::map<int, std::string> ModeCommand(Event& event) = 0;
 		virtual std::map<int, std::string> PrivmsgCommand(Event& event) = 0;
-
-	private:
 
 };
 

--- a/includes/start_event_listener.h
+++ b/includes/start_event_listener.h
@@ -11,6 +11,8 @@ class StartEventListener: public EventListener{
 		StartEventListener(IrcServer& ircServer);
 		~StartEventListener();
 		EventListener*	accept(int fd);
+
+	private:
 		std::map<int, std::string> PassCommand(Event& event);
 		std::map<int, std::string> NickCommand(Event& event);
 		std::map<int, std::string> UserCommand(Event& event);
@@ -21,7 +23,6 @@ class StartEventListener: public EventListener{
 		std::map<int, std::string> PrivmsgCommand(Event& event);
 		std::map<int, std::string> ModeCommand(Event& event);
 
-	private:
 		IrcServer& irc_server_;
 };
 

--- a/includes/user.h
+++ b/includes/user.h
@@ -11,6 +11,11 @@ class User : public EventListener{
 		User();
 		User(int fd);
 		~User();
+		void set_server_password(const std::string& password);
+		bool get_is_password_authenticated() const;
+		int get_fd() const;
+
+	private:
 		std::map<int, std::string> PassCommand(Event& event);
 		std::map<int, std::string> NickCommand(Event& event);
 		std::map<int, std::string> UserCommand(Event& event);
@@ -20,11 +25,7 @@ class User : public EventListener{
 		std::map<int, std::string> TopicCommand(Event& event);
 		std::map<int, std::string> ModeCommand(Event& event);
 		std::map<int, std::string> PrivmsgCommand(Event& event);
-		void set_server_password(const std::string& password);
-		bool get_is_password_authenticated() const;
-		int get_fd() const;
 
-	private:
 		int	fd_;
 		bool	is_password_authenticated_;
 		std::string	nick_name_;

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -1,7 +1,7 @@
 #include "channel.h"
 #include "user.h"
 
-Channel::Channel(){
+Channel::Channel() {
 		(void)max_member_num_;
 		(void)i_mode;
 		(void)t_mode;

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -92,118 +92,19 @@ void	EventHandler::HandlePollInEvent(pollfd entry)
 	}
 }
 
-void	EventHandler::ExecuteCommand(Event event){
-
-	CallStartEventListener(event);
+void	EventHandler::ExecuteCommand(Event event)
+{
+	//start_event_listener_
+	start_event_listener_->ExecuteCommand(response_map_, event);
 
 	int listener_size = event_listeners_.size();
 
 	for (int i = 0; i < listener_size; i++)
 	{
-		switch (event.get_command()){
-			case message::PASS:
-				utils::mergeMaps(response_map_, event_listeners_[i]->PassCommand(event));
-				break;
-			case message::NICK:
-				event_listeners_[i]->NickCommand(event);
-				break;
-			case message::USER:
-				event_listeners_[i]->UserCommand(event);
-				break;
-			case message::JOIN:
-				event_listeners_[i]->JoinCommand(event);
-				break;
-			case message::INVITE:
-				event_listeners_[i]->InviteCommand(event);
-				break;
-			case message::KICK:
-				event_listeners_[i]->KickCommand(event);
-				break;
-			case message::TOPIC:
-				event_listeners_[i]->TopicCommand(event);
-				break;
-			case message::MODE:
-				event_listeners_[i]->ModeCommand(event);
-				break;
-			case message::PRIVMSG:
-				event_listeners_[i]->PrivmsgCommand(event);
-				break;
-			default:
-				return ;
-		}
+		event_listeners_[i]->ExecuteCommand(response_map_, event);
 	}
-	CallEndEventListener(event);
-}
-
-void	EventHandler::CallStartEventListener(Event& event)
-{
-		switch (event.get_command()){
-
-			case message::PASS:
-				start_event_listener_->PassCommand(event);
-				break;
-			case message::NICK:
-				start_event_listener_->NickCommand(event);
-				break;
-			case message::USER:
-				start_event_listener_->UserCommand(event);
-				break;
-			case message::JOIN:
-				start_event_listener_->JoinCommand(event);
-				break;
-			case message::INVITE:
-				start_event_listener_->InviteCommand(event);
-				break;
-			case message::KICK:
-				start_event_listener_->KickCommand(event);
-				break;
-			case message::TOPIC:
-				start_event_listener_->TopicCommand(event);
-				break;
-			case message::MODE:
-				start_event_listener_->ModeCommand(event);
-				break;
-			case message::PRIVMSG:
-				start_event_listener_->PrivmsgCommand(event);
-				break;
-			default:
-				return ;
-		}
-}
-
-void	EventHandler::CallEndEventListener(Event& event)
-{
-	switch (event.get_command()){
-		case message::PASS:
-			end_event_listener_->PassCommand(event);
-			break;
-		case message::NICK:
-			end_event_listener_->NickCommand(event);
-			break;
-		case message::USER:
-			end_event_listener_->UserCommand(event);
-			break;
-		case message::JOIN:
-			end_event_listener_->JoinCommand(event);
-			break;
-		case message::INVITE:
-			end_event_listener_->InviteCommand(event);
-			break;
-		case message::KICK:
-			end_event_listener_->KickCommand(event);
-			break;
-		case message::TOPIC:
-			end_event_listener_->TopicCommand(event);
-			break;
-		case message::MODE:
-			end_event_listener_->ModeCommand(event);
-			break;
-		case message::PRIVMSG:
-			end_event_listener_->PrivmsgCommand(event);
-			break;
-		default:
-			return ;
-	}
+	//end_event_listener_を実行する
+	end_event_listener_->ExecuteCommand(response_map_, event);
 }
 
 void	EventHandler::HandlePollOutEvent(pollfd entry)

--- a/src/event_listener.cpp
+++ b/src/event_listener.cpp
@@ -9,3 +9,39 @@ EventListener::~EventListener()
 {
 	return ;
 }
+
+void EventListener::ExecuteCommand(std::map<int, std::string>& response, Event& event)
+{
+	switch (event.get_command())
+	{
+		case message::PASS:
+			utils::mergeMaps(response, PassCommand(event));
+			break;
+		case message::NICK:
+			utils::mergeMaps(response, NickCommand(event));
+			break;
+		case message::USER:
+			utils::mergeMaps(response, UserCommand(event));
+			break;
+		case message::JOIN:
+			utils::mergeMaps(response, JoinCommand(event));
+			break;
+		case message::INVITE:
+			utils::mergeMaps(response, InviteCommand(event));
+			break;
+		case message::KICK:
+			utils::mergeMaps(response, KickCommand(event));
+			break;
+		case message::TOPIC:
+			utils::mergeMaps(response, TopicCommand(event));
+			break;
+		case message::MODE:
+			utils::mergeMaps(response, ModeCommand(event));
+			break;
+		case message::PRIVMSG:
+			utils::mergeMaps(response, PrivmsgCommand(event));
+			break;
+		default:
+			return ;
+	}
+}


### PR DESCRIPTION
EventListenerに「ExecuteCommand」関数を実装して、コマンドの分岐処理をこの関数で行うように修正しました。
※std::map<int, std::string>& response, Event& eventを引数としてExecuteCommandに渡す
　→コマンドの実行はresponse（map型）に反映し、eventのcommand（string型）を利用してどちらのコマンドを実行するか判断する