### PR TITLE
fix switch default condiction in ExecuteCommand func ofuser.cpp

### DIFF
--- a/src/user.cpp
+++ b/src/user.cpp
@@ -77,6 +77,7 @@ std::pair<int, std::string> User::ExecuteCommand(const Event& event)
 			ret_pair = ExPrivmsgCommand(event);
 			break;
 		default:
+			return ret_pair;
 	}
 	return ret_pair;
 }


### PR DESCRIPTION
conflict解消に必要なswitchのdefaultの条件が削除されたため、その修正をします