### PR TITLE
メッセージ用クラスを作成

### DIFF
--- a/includes/optional_message.h
+++ b/includes/optional_message.h
@@ -15,7 +15,7 @@ class OptionalMessage {
 		OptionalMessage(const OptionalMessage&);
 		~OptionalMessage();
 
-		bool is_empty(void) const;
+		bool isEmpty(void) const;
 		std::pair<int, std::string> MakePair(void) const;
 
 		//例外処理

--- a/src/optional_message.cpp
+++ b/src/optional_message.cpp
@@ -19,18 +19,18 @@ OptionalMessage::OptionalMessage(int fd, const std::string& message)
 }
 
 OptionalMessage::OptionalMessage(const OptionalMessage& src)
-		: is_empty_(src.is_empty()), fd_(src.fd_), message_(src.message_) {
+		: is_empty_(src.isEmpty()), fd_(src.fd_), message_(src.message_) {
 }
 
 OptionalMessage::~OptionalMessage() {
 }
 
-bool OptionalMessage::is_empty() const {
+bool OptionalMessage::isEmpty() const {
 	return this->is_empty_;
 }
 
 std::pair<int, std::string> OptionalMessage::MakePair() const {
-	if (this->is_empty())
+	if (this->isEmpty())
 		throw OptionalMessage::EmptyMessageException();
 	return std::make_pair(this->fd_, this->message_);
 }


### PR DESCRIPTION
試行錯誤の末、この形で実装することにしました。

使い方:
送信したいメッセージを作成してもらって、static関数の「Create」に送信先のfdとメッセージを引数に渡します。メッセージがない場合は、static関数の「Empty」を呼び出してください。
こうして得たインスタンスは、「MakePair」を呼び出してfdとメッセージのpairを得られますが、それを呼ぶ前にまず「is_empty」でメッセージがあるか確認することをおすすめします。
呼ばなくともMakePair内で例外が投げられますが、例外処理は負荷が重いので非推奨です。

参考リンク
[JavaのOptionalクラス](https://docs.oracle.com/javase/jp/8/docs/api/java/util/Optional.html)
[c++のstd::optional](https://cpprefjp.github.io/reference/optional/optional.html)