### PR TITLE
MOD: Ichange sFinished() return value from true false

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -79,7 +79,7 @@ OptionalMessage Channel::ExecuteCommand(const Event& event)
 bool Channel::IsFinished() const
 {
 	//未実装
-	return true;
+	return false;
 }
 
 //Execute

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -86,7 +86,7 @@ std::string User::CreateErrorMessage(const message::Command& cmd, const ErrorSta
 
 bool User::IsFinished() const {
 	//未実装
-	return true;
+	return false;
 }
 
 //Execute


### PR DESCRIPTION
バグかと思いブランチ切りましたが、未実装のFinishableクラス、IsFinished()がデフォルトでtrueを返していることが原因でした。
挙動確認しにくいので、とりあえずreturn falseにしてマージしちゃいます。