### PR TITLE
ChannelEventだった場合にdeleteするよう変更

### DIFF
--- a/includes/event.h
+++ b/includes/event.h
@@ -9,6 +9,7 @@
 class Event {
 	public:
 		Event(int fd, int event_type);
+		Event(const Event&);
 		virtual ~Event();
 		int		get_fd(void) const;
 		int		get_event_type(void) const;
@@ -28,10 +29,6 @@ class Event {
 			private:
 				static const std::string kMessage;
 		};
-
-	protected:
-		Event(const Event&);
-
 
 	private:
 		const int	fd_;

--- a/includes/event_handler.h
+++ b/includes/event_handler.h
@@ -40,7 +40,7 @@ class EventHandler{
 		void				HandlePollInEvent(pollfd entry);
 		void				HandlePollOutEvent(pollfd entry);
 		void				HandlePollHupEvent(pollfd entry);
-		void				ExecuteCommand(Event& event);
+		void				ExecuteCommand(Event event);
 
 		Database&	database_;
 		std::vector<struct pollfd>	poll_fd_;

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -292,7 +292,7 @@ void	EventHandler::Execute(const pollfd& entry, const std::string& msg) {
 				std::cout << "Parse Empty" <<std::endl;
 				break ;
 			default:
-				ExecuteCommand(event);
+				this->ExecuteCommand(event);
 				break;
 		}
 		request_buffer = remain_msg;
@@ -301,10 +301,12 @@ void	EventHandler::Execute(const pollfd& entry, const std::string& msg) {
 		request_map_.insert(std::make_pair(entry.fd, request_buffer));
 }
 
-void EventHandler::ExecuteCommand(Event& event)
+void EventHandler::ExecuteCommand(Event event)
 {
 	database_.CheckEvent(event);
 	AddResponseMap(database_.ExecuteEvent(event));
+	if (event.IsChannelEvent())
+		delete &event;
 	database_.DeleteFinishedElements();
 }
 


### PR DESCRIPTION
EventHandler内のExecuteEventでeventをdeleteする都合上、関数外に影響を及ぼさないために、引数を参照でなくしました。
これにより、コピーコンストラクタが必要になったため、Eventのコピーコンストラクタをprotected->publicに変更しました。
Check内で分岐させているコマンド系の関数の引数は各自変更してください。