### PR TITLE
Eventをnewして、Checkにはポインタの参照渡しに変更

### DIFF
--- a/includes/channel.h
+++ b/includes/channel.h
@@ -15,7 +15,7 @@ class Channel: public EventListener, public EventConfigurator {
 				const std::string& key = "", int max_num = 10);
 		~Channel();
 
-		void CheckCommand(Event& event) const;
+		void CheckCommand(Event*& event) const;
 		OptionalMessage ExecuteCommand(const Event& event);
 		bool IsFinished(void) const;
 		void AddUser(const User&);

--- a/includes/database.h
+++ b/includes/database.h
@@ -17,7 +17,7 @@ class Database {
 		void CreateChannel(void);
 		void DeleteFinishedElements(void);
 
-		void CheckEvent(Event& event) const;
+		void CheckEvent(Event*& event) const;
 		std::map<int, std::string> ExecuteEvent(const Event& event);
 		const std::string& get_server_password() const;
 	private:

--- a/includes/event.h
+++ b/includes/event.h
@@ -11,7 +11,6 @@ class User;
 class Event {
 	public:
 		Event(int fd, int event_type);
-		Event(const Event&);
 		virtual ~Event();
 		int		get_fd(void) const;
 		int		get_event_type(void) const;
@@ -47,6 +46,9 @@ class Event {
 			private:
 				static const std::string kMessage;
 		};
+
+	protected:
+		Event(const Event&);
 
 	private:
 		const int	fd_;

--- a/includes/event_configurator.h
+++ b/includes/event_configurator.h
@@ -8,7 +8,7 @@ class EventConfigurator : virtual public Finishable {
 	public:
 		EventConfigurator() {}
 		virtual ~EventConfigurator() {}
-		virtual void CheckCommand(Event& event) const = 0;
+		virtual void CheckCommand(Event*& event) const = 0;
 };
 
 #endif

--- a/includes/event_handler.h
+++ b/includes/event_handler.h
@@ -40,7 +40,7 @@ class EventHandler{
 		void				HandlePollInEvent(pollfd entry);
 		void				HandlePollOutEvent(pollfd entry);
 		void				HandlePollHupEvent(pollfd entry);
-		void				ExecuteCommand(Event event);
+		void				ExecuteCommand(Event*& event);
 
 		Database&	database_;
 		std::vector<struct pollfd>	poll_fd_;

--- a/includes/user.h
+++ b/includes/user.h
@@ -14,7 +14,7 @@ class User : public EventListener, public EventConfigurator {
 		User(int fd);
 		~User();
 
-		void CheckCommand(Event& event) const;
+		void CheckCommand(Event*& event) const;
 		OptionalMessage ExecuteCommand(const Event& event);
 		std::string CreateErrorMessage(const message::Command& cmd, const ErrorStatus& err_status) const;
 		bool IsFinished(void) const;

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -82,34 +82,34 @@ bool Channel::VerifyKey(const std::string& key) const {
 	return (this->key_ == key);
 }
 
-void Channel::CheckCommand(Event& event) const {
-	switch (event.get_command()) {
+void Channel::CheckCommand(Event*& event) const {
+	switch (event->get_command()) {
 		case message::kPass:
-			CkPassCommand(event);
+			CkPassCommand(*event);
 			break;
 		case message::kNick:
-			CkNickCommand(event);
+			CkNickCommand(*event);
 			break;
 		case message::kUser:
-			CkUserCommand(event);
+			CkUserCommand(*event);
 			break;
 		case message::kJoin:
-			CkJoinCommand(event);
+			CkJoinCommand(*event);
 			break;
 		case message::kInvite:
-			CkInviteCommand(event);
+			CkInviteCommand(*event);
 			break;
 		case message::kKick:
-			CkKickCommand(event);
+			CkKickCommand(*event);
 			break;
 		case message::kTopic:
-			CkTopicCommand(event);
+			CkTopicCommand(*event);
 			break;
 		case message::kMode:
-			CkModeCommand(event);
+			CkModeCommand(*event);
 			break;
 		case message::kPrivmsg:
-			CkPrivmsgCommand(event);
+			CkPrivmsgCommand(*event);
 			break;
 		default:
 			return;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -16,8 +16,8 @@ void Database::CreateUser(int fd) {
 	}
 }
 
-void Database::CheckEvent(Event& event) const {
-	Database::CheckCommandAndParams(event);
+void Database::CheckEvent(Event*& event) const {
+	Database::CheckCommandAndParams(*event);
 	std::size_t vector_length = check_element_.size();
 
 	for (std::size_t i = 0; i < vector_length; i++)

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -8,37 +8,37 @@ User::User(int fd) : fd_(fd), is_password_authenticated_(false), is_delete_(fals
 User::~User() {
 }
 
-void User::CheckCommand(Event& event) const {
-	if (event.get_fd() == this->get_fd())
-		event.set_executer(*this);
+void User::CheckCommand(Event*& event) const {
+	if (event->get_fd() == this->get_fd())
+		event->set_executer(*this);
 
-	switch (event.get_command()) {
+	switch (event->get_command()) {
 		case message::kPass:
-			CkPassCommand(event);
+			CkPassCommand(*event);
 			break;
 		case message::kNick:
-			CkNickCommand(event);
+			CkNickCommand(*event);
 			break;
 		case message::kUser:
-			CkUserCommand(event);
+			CkUserCommand(*event);
 			break;
 		case message::kJoin:
-			CkJoinCommand(event);
+			CkJoinCommand(*event);
 			break;
 		case message::kInvite:
-			CkInviteCommand(event);
+			CkInviteCommand(*event);
 			break;
 		case message::kKick:
-			CkKickCommand(event);
+			CkKickCommand(*event);
 			break;
 		case message::kTopic:
-			CkTopicCommand(event);
+			CkTopicCommand(*event);
 			break;
 		case message::kMode:
-			CkModeCommand(event);
+			CkModeCommand(*event);
 			break;
 		case message::kPrivmsg:
-			CkPrivmsgCommand(event);
+			CkPrivmsgCommand(*event);
 			break;
 		default:
 			break;


### PR DESCRIPTION
[前回](https://github.com/IRC-WIR/ft_irc/pull/82)から、さらに変更を加え、newして渡すことにしました。
(makeによるコンパイルエラーは確認済み)

使い方:
EventをChannelEventに変えたい関数では、ポインタの参照(Event*&)を引数に渡す。
中身では、delete event -> event = new ChannelEvent() という順で実行する。
↑ deleteは必須！置き換えるときはいつでも実行すること