### PR TITLE
UPDATE modify parsing add empty string to params

### DIFF
--- a/includes/message.h
+++ b/includes/message.h
@@ -29,7 +29,7 @@ enum ParseState
 	kParseParam,
 	kParseError,
 	kParseEmpty,
-	KParseNotAscii,
+	kParseNotAscii,
 	kParseComplete
 };
 

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -22,6 +22,7 @@ namespace utils {
 	bool IsAsciiStr(const std::string& str);
 	void ConvertToUpper(std::string& str);
 	bool HasNewlines(const std::string& str);
+	bool HasDelimator(const std::string& str, const std::string& delim);
 
 	//debug
 	void PrintStringVector(const std::vector<std::string>& str_vec);

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -22,7 +22,6 @@ namespace utils {
 	bool IsAsciiStr(const std::string& str);
 	void ConvertToUpper(std::string& str);
 	bool HasNewlines(const std::string& str);
-	bool HasDelimator(const std::string& str, const std::string& delim);
 
 	//debug
 	void PrintStringVector(const std::vector<std::string>& str_vec);

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -14,8 +14,8 @@ namespace utils {
 	void CheckPort(std::string port);
 	void CheckPassword(std::string password);
 	int	Stoi(std::string num_str);
-	std::string SplitBefore(const std::string& str, const std::string& delim);
-	std::string SplitAfter(const std::string& str, const std::string& delim);
+	std::string TrimBefore(const std::string& str, const std::string& delim);
+	std::string TrimAfter(const std::string& str, const std::string& delim);
 	void EraseNewline(std::string& str);
 	void EraseSpace(std::string& str);
 	bool IsAscii(char c);

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -260,9 +260,9 @@ void	EventHandler::Execute(const pollfd& entry, const std::string& msg) {
 	//request_buffer:
 	//pattern1:command1\ncommand2\ncommand3\n
 	while (utils::HasNewlines(request_buffer)) {
-		parsing_msg = utils::SplitBefore(request_buffer, "\n");
+		parsing_msg = utils::TrimBefore(request_buffer, "\n");
 		parsing_msg += "\n";
-		remain_msg = utils::SplitAfter(request_buffer, "\n");
+		remain_msg = utils::TrimAfter(request_buffer, "\n");
 		//eventを作成
 		Event* event = new Event(entry.fd, entry.revents);
 		//parse

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -279,7 +279,7 @@ void	EventHandler::Execute(const pollfd& entry, const std::string& msg) {
 		case message::kParseError:
 			std::cout << "Parse Error" <<std::endl;
 			break ;
-		case message::KParseNotAscii:
+		case message::kParseNotAscii:
 			//have to define the action of inputting out range of Ascii
 			std::cout << "Not Ascii code input" << std::endl;
 			break;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -48,7 +48,7 @@ void MessageParser::ParsingMessage(const std::string& msg)
 	if (!utils::IsAsciiStr(message_))
 	{
 		command_ = kNotFound;
-		state_ = KParseNotAscii;
+		state_ = kParseNotAscii;
 		return;
 	}
 	std::string last_param = "";

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -53,7 +53,7 @@ void MessageParser::ParsingMessage(const std::string& msg)
 	}
 	std::string last_param;
 	std::string command = message_;
-	bool has_delim = utils::HasDelimator(message_, ":");
+	bool has_delim = false;
 	while (!IsFinishParsing())
 	{
 		switch (state_)
@@ -74,6 +74,7 @@ void MessageParser::ParsingMessage(const std::string& msg)
 				last_param = utils::SplitAfter(message_, ":");
 				if (!last_param.empty())
 				{
+					has_delim = true;
 					utils::EraseNewline(last_param);
 					command = utils::SplitBefore(message_, ":");
 				}

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -53,12 +53,14 @@ void MessageParser::ParsingMessage(const std::string& msg)
 	}
 	std::string last_param = "";
 	std::string command = message_;
-	bool has_delim = message_.find(":") != message_.npos;
+	const std::string kDelim = ":";
+	std::string::size_type delim_pos = message_.find(kDelim);
+	bool has_delim = (delim_pos != std::string::npos);
 
 	if (has_delim) {
-		last_param = utils::TrimAfter(message_, ":");
+		last_param = message_.substr(delim_pos + kDelim.length());
 		utils::EraseNewline(last_param);
-		command = utils::TrimBefore(message_, ":");
+		command = message_.substr(0, delim_pos);
 	}
 	state_ = kParseCommand;
 	while (!IsFinishParsing())

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -62,8 +62,7 @@ void MessageParser::ParsingMessage(const std::string& msg)
 				break;
 
 			case kParseParam:
-				if (!last_param.empty())
-					command_params_.push_back(last_param);
+				command_params_.push_back(last_param);
 				state_ = kParseComplete;
 				break;
 
@@ -86,7 +85,7 @@ void MessageParser::ParsingCommand(const std::string& command)
 {
 	std::stringstream ss(command);
 	std::string	str;
-	while ( getline(ss, str, ' ') ){
+	while ( getline(ss, str, ' ') ) {
 		utils::EraseNewline(str);
 		if (!str.empty())
 			command_params_.push_back(str);

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -62,7 +62,8 @@ void MessageParser::ParsingMessage(const std::string& msg)
 				break;
 
 			case kParseParam:
-				command_params_.push_back(last_param);
+				if (message_.find(":") != message_.npos)
+					command_params_.push_back(last_param);
 				state_ = kParseComplete;
 				break;
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -53,6 +53,7 @@ void MessageParser::ParsingMessage(const std::string& msg)
 	}
 	std::string last_param;
 	std::string command = message_;
+	bool has_delim = utils::HasDelimator(message_, ":");
 	while (!IsFinishParsing())
 	{
 		switch (state_)
@@ -62,7 +63,7 @@ void MessageParser::ParsingMessage(const std::string& msg)
 				break;
 
 			case kParseParam:
-				if (message_.find(":") != message_.npos)
+				if (has_delim)
 					command_params_.push_back(last_param);
 				state_ = kParseComplete;
 				break;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -110,7 +110,7 @@ void MessageParser::ParsingCommand(const std::string& command)
 		state_ = kParseError;
 		return;
 	}
-	//find command, remove commmand string from commad_params vector
+	//find command, remove command string from command_params vector
 	command_params_.erase(command_params_.begin());
 	command_ = it->second;
 	state_ = kParseParam;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -51,9 +51,16 @@ void MessageParser::ParsingMessage(const std::string& msg)
 		state_ = KParseNotAscii;
 		return;
 	}
-	std::string last_param;
+	std::string last_param = "";
 	std::string command = message_;
-	bool has_delim = false;
+	bool has_delim = message_.find(":") != message_.npos;
+
+	if (has_delim) {
+		last_param = utils::TrimAfter(message_, ":");
+		utils::EraseNewline(last_param);
+		command = utils::TrimBefore(message_, ":");
+	}
+	state_ = kParseCommand;
 	while (!IsFinishParsing())
 	{
 		switch (state_)
@@ -69,17 +76,7 @@ void MessageParser::ParsingMessage(const std::string& msg)
 				break;
 
 			default:
-			//debug in parsing
-				std::cout << "message_:" << message_ << std::endl;
-				last_param = utils::SplitAfter(message_, ":");
-				if (!last_param.empty())
-				{
-					has_delim = true;
-					utils::EraseNewline(last_param);
-					command = utils::SplitBefore(message_, ":");
-				}
-				state_ = kParseCommand;
-				break;
+				return;
 		}
 	}
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -113,6 +113,10 @@ bool HasNewlines(const std::string& str) {
 	return true;
 }
 
+bool HasDelimator(const std::string& str, const std::string& delim) {
+	return str.find(delim) != str.npos;
+}
+
 UtilsException::UtilsException(const std::string& msg) : std::invalid_argument(msg) {};
 
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -35,14 +35,14 @@ int Stoi(std::string num_str) {
 	return (num_int);
 }
 
-std::string SplitBefore(const std::string& str, const std::string& delim) {
+std::string TrimBefore(const std::string& str, const std::string& delim) {
 	std::string::size_type n = str.find(delim);
 	if (n == std::string::npos)
 		return "";
 	return str.substr(0, n);
 }
 
-std::string SplitAfter(const std::string& str, const std::string& delim) {
+std::string TrimAfter(const std::string& str, const std::string& delim) {
 	std::string::size_type n = str.find(delim);
 	if (n == std::string::npos)
 		return "";

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,5 @@
 #include "utils.h"
 
-
 namespace utils{
 
 void CheckPort(std::string num_str) {
@@ -111,10 +110,6 @@ bool HasNewlines(const std::string& str) {
 	if (find_n_type == std::string::npos && find_r_n_type == std::string::npos)
 		return false;
 	return true;
-}
-
-bool HasDelimator(const std::string& str, const std::string& delim) {
-	return str.find(delim) != str.npos;
 }
 
 UtilsException::UtilsException(const std::string& msg) : std::invalid_argument(msg) {};

--- a/test/MessageErrorTest.cpp
+++ b/test/MessageErrorTest.cpp
@@ -50,5 +50,5 @@ TEST(MessageErrorTest, ParsingErrorTest4) {
   //Expect not found command.
   EXPECT_EQ(message::kNotFound, message_parser.get_command());
   //Expect ParseError state.
-  EXPECT_EQ(message::KParseNotAscii, message_parser.get_state());
+  EXPECT_EQ(message::kParseNotAscii, message_parser.get_state());
 }

--- a/test/MessageTest.cpp
+++ b/test/MessageTest.cpp
@@ -154,20 +154,27 @@ TEST(MessageTest, ParsingTest9) {
 
   std::string raw_upper_message =
     "PRIVMSG user : test_to_send\r\n";
-  std::string raw_lower_message =
+  std::string num_1 =
+    "PRIVmsg #ch1 \r\n";
+  std::string num_2 =
     "PRIVmsg #ch1 :\r\n";
   message::MessageParser message_upper_parser(raw_upper_message);
-  message::MessageParser message_lower_parser(raw_lower_message);
+  message::MessageParser message_num_1(num_1);
+  message::MessageParser message_num_2(num_2);
   // Expect PRIVMSG command.
   EXPECT_EQ(message::kPrivmsg, message_upper_parser.get_command());
   // Expect PRIVMSG command.
-  EXPECT_EQ(message::kPrivmsg, message_lower_parser.get_command());
+  EXPECT_EQ(message::kPrivmsg, message_num_1.get_command());
   // Expect PRIVMSG command param[0]
   EXPECT_EQ("user", message_upper_parser.get_params()[0]);
   // Expect PRIVMSG last command param
   EXPECT_EQ(" test_to_send", message_upper_parser.get_params()[1]);
-  // Expect PRIVMSG last empty command param
-  EXPECT_EQ("", message_lower_parser.get_params()[1]);
+  // Expect the num of paramater {"#ch1"} → 1
+  EXPECT_EQ(1, message_num_1.get_params().size());
+  // // Expect the num of paramater {"#ch1",""} → 2
+  EXPECT_EQ(2, message_num_2.get_params().size());
+  // // Expect PRIVMSG last empty command param
+  EXPECT_EQ("", message_num_2.get_params()[1]);
 }
 
 //test QUIT command
@@ -198,7 +205,6 @@ TEST(MessageTest, ParsingTest11) {
   EXPECT_EQ("1234abcd", message_parser.get_params()[0]);
   // Expect last command params.
   EXPECT_EQ(" space_include_last_param: ", message_parser.get_params()[1]);
-
 }
 
 // // test lower_case parsing

--- a/test/MessageTest.cpp
+++ b/test/MessageTest.cpp
@@ -155,7 +155,7 @@ TEST(MessageTest, ParsingTest9) {
   std::string raw_upper_message =
     "PRIVMSG user : test_to_send\r\n";
   std::string raw_lower_message =
-    "PRIVmsg #ch1 : test_to_send\r\n";
+    "PRIVmsg #ch1 :\r\n";
   message::MessageParser message_upper_parser(raw_upper_message);
   message::MessageParser message_lower_parser(raw_lower_message);
   // Expect PRIVMSG command.
@@ -166,6 +166,8 @@ TEST(MessageTest, ParsingTest9) {
   EXPECT_EQ("user", message_upper_parser.get_params()[0]);
   // Expect PRIVMSG last command param
   EXPECT_EQ(" test_to_send", message_upper_parser.get_params()[1]);
+  // Expect PRIVMSG last empty command param
+  EXPECT_EQ("", message_lower_parser.get_params()[1]);
 }
 
 //test QUIT command


### PR DESCRIPTION
最後の文字列を示す「：」の後ろにemptyになった場合でも、paramsに追加するように修正しました。

テスト
 "PRIVmsg #ch1 :\r\n";

↓ パーシング

command: PRIVMSG
commands: "#ch1" ""
