### PR TITLE
JOINコマンドを実装

### DIFF
--- a/includes/channel.h
+++ b/includes/channel.h
@@ -57,7 +57,7 @@ class Channel: public EventListener, public EventConfigurator {
 		void CkPassCommand(Event& event) const;
 		void CkNickCommand(Event& event) const;
 		void CkUserCommand(Event& event) const;
-		void CkJoinCommand(Event& event) const;
+		void CkJoinCommand(Event*& event) const;
 		void CkInviteCommand(Event& event) const;
 		void CkKickCommand(Event& event) const;
 		void CkTopicCommand(Event& event) const;

--- a/includes/channel.h
+++ b/includes/channel.h
@@ -38,10 +38,18 @@ class Channel: public EventListener, public EventConfigurator {
 		};
 
 	private:
+		template <typename T, typename U>
+		class MyMap : public std::map<T, U> {
+			public:
+				const U& operator() (const U& key) const {
+					return this->find(key)->second;
+				}
+		};
+
 		const std::string name_;
 		std::string topic_;
 		// i,t,k,o,lは少なくとも実装
-		std::map<char, bool> mode_map;
+		MyMap<char, bool> mode_map;
 		std::string key_;
 		int max_member_num_;
 		std::vector<const User*> users_;

--- a/includes/channel.h
+++ b/includes/channel.h
@@ -11,6 +11,8 @@
 
 class Channel: public EventListener, public EventConfigurator {
 	public:
+		static const int kMaxJoiningChannels = 10;
+
 		Channel(const User& op, const std::string& name);
 		~Channel();
 
@@ -23,19 +25,13 @@ class Channel: public EventListener, public EventConfigurator {
 		bool RemoveUserByNick(const std::string&);
 		bool ContainsUser(const User&) const;
 		bool ContainsUserByNick(const std::string&) const;
-		void set_operator(const User&);
-		const User& get_operator(void) const;
+		bool GiveOperator(const User&);
+		bool TakeOperator(const User&);
+		bool IsOperator(const User&) const;
 		void set_topic(const std::string&);
 		const std::string& get_topic(void) const;
-		bool VerifyKey(const std::string&) const;
-
-		class NoOperatorException : public std::runtime_error {
-			public:
-				NoOperatorException(void);
-
-			private:
-				static const std::string kErrorMessage;
-		};
+		const std::string& get_name(void) const;
+		std::string GenerateMemberList(void) const;
 
 	private:
 		template <typename T, typename U>
@@ -49,13 +45,12 @@ class Channel: public EventListener, public EventConfigurator {
 		const std::string name_;
 		std::string topic_;
 		// i,t,k,o,lは少なくとも実装
-		MyMap<char, bool> mode_map;
+		MyMap<char, bool> mode_map_;
 		std::string key_;
-		int max_member_num_;
-		std::vector<const User*> users_;
-		const User* operator_;
+		std::size_t max_member_num_;
+		utils::MyVector<const User*> operators_;
+		utils::MyVector<const User*> members_;
 
-		void RemoveUserBasic(std::vector<const User*>::iterator&);
 		void InitModeMap(void);
 
 		//check command

--- a/includes/channel.h
+++ b/includes/channel.h
@@ -7,12 +7,11 @@
 #include "user.h"
 #include "optional_message.h"
 #include <stdexcept>
+#include <map>
 
 class Channel: public EventListener, public EventConfigurator {
 	public:
-		// max_numは仮
-		Channel(const User& op, const std::string& name,
-				const std::string& key = "", int max_num = 10);
+		Channel(const User& op, const std::string& name);
 		~Channel();
 
 		void CheckCommand(Event*& event) const;
@@ -40,18 +39,16 @@ class Channel: public EventListener, public EventConfigurator {
 
 	private:
 		const std::string name_;
-		const std::string key_;
-		const int max_member_num_;
 		std::string topic_;
-		//bool i_mode;
-		//bool t_mode;
-		//bool k_mode;
-		//bool o_mode;
-		//bool l_mode;
+		// i,t,k,o,lは少なくとも実装
+		std::map<char, bool> mode_map;
+		std::string key_;
+		int max_member_num_;
 		std::vector<const User*> users_;
 		const User* operator_;
 
 		void RemoveUserBasic(std::vector<const User*>::iterator&);
+		void InitModeMap(void);
 
 		//check command
 		void CkPassCommand(Event& event) const;

--- a/includes/channel.h
+++ b/includes/channel.h
@@ -38,8 +38,13 @@ class Channel: public EventListener, public EventConfigurator {
 		class MyMap : public std::map<T, U> {
 			public:
 				const U& operator() (const U& key) const {
-					return this->find(key)->second;
+					const typename MyMap<T, U>::const_iterator it = this->find(key);
+					if (it == this->end())
+						throw std::out_of_range(MyMap<T, U>::kErrMsg);
+					return it->second;
 				}
+			private:
+				static const std::string kErrMsg;
 		};
 
 		const std::string name_;

--- a/includes/channel.h
+++ b/includes/channel.h
@@ -32,12 +32,13 @@ class Channel: public EventListener, public EventConfigurator {
 		const std::string& get_topic(void) const;
 		const std::string& get_name(void) const;
 		std::string GenerateMemberList(void) const;
+		std::string GenerateMemberListWithNewUser(const User&) const;
 
 	private:
 		template <typename T, typename U>
 		class MyMap : public std::map<T, U> {
 			public:
-				const U& operator() (const U& key) const {
+				const U& operator() (const T& key) const {
 					const typename MyMap<T, U>::const_iterator it = this->find(key);
 					if (it == this->end())
 						throw std::out_of_range(MyMap<T, U>::kErrMsg);
@@ -56,6 +57,7 @@ class Channel: public EventListener, public EventConfigurator {
 		utils::MyVector<const User*> operators_;
 		utils::MyVector<const User*> members_;
 
+		Channel(const Channel&);
 		void InitModeMap(void);
 
 		//check command

--- a/includes/database.h
+++ b/includes/database.h
@@ -6,20 +6,21 @@
 # include "event_listener.h"
 # include "event_configurator.h"
 # include "user.h"
+# include <string>
 
 class Database {
-
 	public:
 		Database(const std::string& password);
 		~Database();
 
 		void CreateUser(int fd);
-		void CreateChannel(void);
+		const Channel& CreateChannel(const User&, const std::string&);
 		void DeleteFinishedElements(void);
 
 		void CheckEvent(Event*& event) const;
 		std::map<int, std::string> ExecuteEvent(const Event& event);
 		const std::string& get_server_password() const;
+
 	private:
 		Database();
 		std::vector<EventConfigurator*> check_element_;

--- a/includes/database.h
+++ b/includes/database.h
@@ -28,6 +28,7 @@ class Database {
 		const std::string& server_password_;
 
 		void CheckCommandAndParams(Event& event) const;
+		void AfterCheck(Event&) const;
 		//check command
 		void CkPassCommand(Event& event) const;
 		void CkNickCommand(Event& event) const;

--- a/includes/error_status.h
+++ b/includes/error_status.h
@@ -6,12 +6,17 @@
 class ErrorStatus {
     public:
         static const ErrorStatus
+			ERR_NOSUCHCHANNEL,
+			ERR_TOOMANYCHANNELS,
             ERR_NONICKNAMEGIVEN,
             ERR_ERRONEUSNICKNAME,
             ERR_NICKNAMEINUSE,
             ERR_NEEDMOREPARAMS,
             ERR_ALREADYREGISTRED,
-            ERR_PASSWDMISMATCH
+            ERR_PASSWDMISMATCH,
+			ERR_CHANNELISFULL,
+			ERR_INVITEONLYCHAN,
+			ERR_BADCHANNELKEY
             ;
 
         const std::string& get_error_message(void) const;

--- a/includes/event.h
+++ b/includes/event.h
@@ -24,6 +24,9 @@ class Event {
 		virtual bool IsChannelEvent(void) const;
 		void set_executer(const User&);
 		const User& get_executer(void) const;
+		void set_do_nothing(bool);
+		bool is_do_nothing(void) const;
+		bool IsExecutable(void) const;
 
 		class NoErrorException : public std::runtime_error {
 			public:
@@ -57,6 +60,7 @@ class Event {
 		std::vector<std::string>	command_params_;
 		const ErrorStatus* error_status_;
 		const User* executer_;
+		bool is_do_nothing_;
 };
 
 #endif

--- a/includes/event.h
+++ b/includes/event.h
@@ -26,7 +26,6 @@ class Event {
 		const User& get_executer(void) const;
 		void set_do_nothing(bool);
 		bool is_do_nothing(void) const;
-		bool IsExecutable(void) const;
 
 		class NoErrorException : public std::runtime_error {
 			public:

--- a/includes/event_handler.h
+++ b/includes/event_handler.h
@@ -41,6 +41,9 @@ class EventHandler{
 		void				HandlePollOutEvent(pollfd entry);
 		void				HandlePollHupEvent(pollfd entry);
 		void				ExecuteCommand(Event*& event);
+		void				AddNewChannel(Event*&);
+
+		static bool			CheckNewChannel(const Event&);
 
 		Database&	database_;
 		std::vector<struct pollfd>	poll_fd_;

--- a/includes/user.h
+++ b/includes/user.h
@@ -29,7 +29,7 @@ class User : public EventListener, public EventConfigurator {
 		const std::string& get_real_name(void) const;
 
 	private:
-		User();
+		User(void);
 		int		fd_;
 
 		bool	is_password_authenticated_;
@@ -37,6 +37,9 @@ class User : public EventListener, public EventConfigurator {
 		std::string	user_name_;
 		std::string	real_name_;
 		bool is_delete_;
+		utils::MyVector<const Channel*> joining_channels_;
+
+		std::string GenerateJoinDetailMessage(const Channel&) const;
 
 		//check command
 		void CkPassCommand(Event& event) const;

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -9,6 +9,7 @@
 #include <cstring> //for std::memset
 #include <utility> //for std::pair
 #include <set> //for std::set
+#include <algorithm> // for std::find
 
 namespace utils {
 	void CheckPort(std::string port);
@@ -22,6 +23,22 @@ namespace utils {
 	bool IsAsciiStr(const std::string& str);
 	void ConvertToUpper(std::string& str);
 	bool HasNewlines(const std::string& str);
+	std::string StrToLower(const std::string&);
+
+	template <typename T>
+	class MyVector : public std::vector<T> {
+		public:
+			bool Contains(const T& t) const {
+				return (std::find(this->begin(), this->end(), t) != this->end());
+			}
+			bool Remove(const T& t) {
+				typename MyVector<T>::iterator it = std::find(this->begin(), this->end(), t);
+				if (it == this->end())
+					return false;
+				this->erase(it);
+				return true;
+			}
+	};
 
 	//debug
 	void PrintStringVector(const std::vector<std::string>& str_vec);

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -89,7 +89,7 @@ const std::string& Channel::get_topic() const {
 }
 
 bool Channel::VerifyKey(const std::string& key) const {
-	return (!this->mode_map.find('k')->second || this->key_ == key);
+	return (!this->mode_map('k') || this->key_ == key);
 }
 
 void Channel::CheckCommand(Event*& event) const {
@@ -224,13 +224,17 @@ void Channel::CkJoinCommand(Event*& event) const {
 		return ;
 
 	const std::vector<std::string> params = event->get_command_params();
-	if (params[0] == this->name_) {
-		const std::string key = params.size() >= 2 ? params[1] : "";
-		if (!this->VerifyKey(key)) {
-			event->set_error_status(ErrorStatus::ERR_ALREADYREGISTRED);
-			return ;
-		}
-		if 
+	if (params[0] != this->name_)
+		return ;
+
+	const std::string key = params.size() >= 2 ? params[1] : "";
+	if (!this->VerifyKey(key))
+		event->set_error_status(ErrorStatus::ERR_ALREADYREGISTRED);
+	else if (mode_map('i'))
+		event->set_error_status(ErrorStatus::ERR_ALREADYREGISTRED);
+	else if (mode_map('l') && this->users_.size() == this->max_member_num_)
+		event->set_error_status(ErrorStatus::ERR_ALREADYREGISTRED);
+	else {
 		ChannelEvent* channel_event = new ChannelEvent(*event, *this);
 		delete event;
 		event = channel_event;

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -3,6 +3,9 @@
 #include "utils.h"
 #include <algorithm>
 
+template <typename T, typename U>
+const std::string Channel::MyMap<T, U>::kErrMsg("not found the key");
+
 Channel::Channel(const User& op, const std::string& name)
 		: name_(name) {
 	this->operators_.push_back(&op);
@@ -197,7 +200,6 @@ OptionalMessage Channel::ExUserCommand(const Event& event) {
 
 OptionalMessage Channel::ExJoinCommand(const Event& event) {
 	if (event.HasErrorOccurred()
-			|| event.is_do_nothing()
 			|| !event.IsChannelEvent())
 		return OptionalMessage::Empty();
 

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -21,7 +21,6 @@ void Channel::InitModeMap() {
 	this->mode_map_['i'] = false;
 	this->mode_map_['t'] = false;
 	this->mode_map_['k'] = false;
-	this->mode_map_['o'] = false;
 	this->mode_map_['l'] = false;
 }
 
@@ -267,6 +266,9 @@ void Channel::CkJoinCommand(Event*& event) const {
 	if (utils::StrToLower(params[0]) != utils::StrToLower(this->name_))
 		return ;
 
+	ChannelEvent* channel_event = new ChannelEvent(*event, *this);
+	delete event;
+	event = channel_event;
 	const std::string key = params.size() >= 2 ? params[1] : "";
 	if (this->mode_map_('k') && this->key_ != key)
 		event->set_error_status(ErrorStatus::ERR_BADCHANNELKEY);
@@ -274,11 +276,6 @@ void Channel::CkJoinCommand(Event*& event) const {
 		event->set_error_status(ErrorStatus::ERR_INVITEONLYCHAN);
 	else if (this->mode_map_('l') && this->operators_.size() + this->members_.size() >= this->max_member_num_)
 		event->set_error_status(ErrorStatus::ERR_CHANNELISFULL);
-	else {
-		ChannelEvent* channel_event = new ChannelEvent(*event, *this);
-		delete event;
-		event = channel_event;
-	}
 }
 
 void Channel::CkInviteCommand(Event& event) const {

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -4,13 +4,22 @@
 
 const std::string Channel::NoOperatorException::kErrorMessage("Channel has no operator");
 
-Channel::Channel(const User& op, const std::string& name, const std::string& key, int max_num)
-		: name_(name), key_(key), max_member_num_(max_num), operator_(&op) {
-	return ;
+Channel::Channel(const User& op, const std::string& name)
+		: name_(name), operator_(&op) {
+	this->InitModeMap();
 }
 
 Channel::~Channel() {
 	return ;
+}
+
+void Channel::InitModeMap() {
+	this->mode_map.clear();
+	this->mode_map['i'] = false;
+	this->mode_map['t'] = false;
+	this->mode_map['k'] = false;
+	this->mode_map['o'] = false;
+	this->mode_map['l'] = false;
 }
 
 void Channel::AddUser(const User& user) {
@@ -80,7 +89,7 @@ const std::string& Channel::get_topic() const {
 }
 
 bool Channel::VerifyKey(const std::string& key) const {
-	return (this->key_.empty() || this->key_ == key);
+	return (!this->mode_map.find('k')->second || this->key_ == key);
 }
 
 void Channel::CheckCommand(Event*& event) const {
@@ -221,6 +230,7 @@ void Channel::CkJoinCommand(Event*& event) const {
 			event->set_error_status(ErrorStatus::ERR_ALREADYREGISTRED);
 			return ;
 		}
+		if 
 		ChannelEvent* channel_event = new ChannelEvent(*event, *this);
 		delete event;
 		event = channel_event;

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -104,17 +104,25 @@ const std::string& Channel::get_name() const {
 	return this->name_;
 }
 
+std::string Channel::GenerateMemberListWithNewUser(const User& new_user) const {
+	std::string ret = this->GenerateMemberList();
+	if (this->ContainsUser(new_user))
+		return ret;
+	else
+		return ret + " " + new_user.get_nick_name();
+}
+
 std::string Channel::GenerateMemberList() const {
 	std::stringstream ss;
 	for (std::size_t i = 0; i < this->operators_.size(); i++) {
 		if (i != 0)
 			ss << " ";
-		ss << "@" << this->operators_[i];
+		ss << "@" << this->operators_[i]->get_nick_name();
 	}
 	for (std::size_t i = 0; i < this->members_.size(); i++) {
 		if (!this->operators_.empty() || i != 0)
 			ss << " ";
-		ss << this->members_[i];
+		ss << this->members_[i]->get_nick_name();
 	}
 	return ss.str();
 }
@@ -204,7 +212,7 @@ OptionalMessage Channel::ExJoinCommand(const Event& event) {
 		return OptionalMessage::Empty();
 
 	const Channel& channel = dynamic_cast<const ChannelEvent&>(event).get_channel();
-	if (this == &channel)
+	if (this == &channel && !this->ContainsUser(event.get_executer()))
 		this->AddUser(event.get_executer());
 	return OptionalMessage::Empty();
 }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1,5 +1,6 @@
 #include "database.h"
 #include "message.h"
+#include "channel.h"
 
 Database::Database(const std::string& password):server_password_(password){};
 Database::~Database(){};
@@ -14,6 +15,13 @@ void Database::CreateUser(int fd) {
 	} catch(const std::invalid_argument& e) {
 		std::cerr << e.what() << std::endl;
 	}
+}
+
+const Channel& Database::CreateChannel(const User& op, const std::string& name) {
+	Channel* channel = new Channel(op, name);
+	this->check_element_.push_back(channel);
+	this->execute_element_.push_back(channel);
+	return *channel;
 }
 
 void Database::CheckEvent(Event*& event) const {

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -171,12 +171,13 @@ void Database::CkJoinCommand(Event& event) const {
 		event.set_error_status(ErrorStatus::ERR_NEEDMOREPARAMS);
 		return ;
 	}
-	if (params[0].empty() || params[0][0] != kStartChar || params[0].length() > kNameMaxLength) {
+	const std::string& channel_name = params[0];
+	if (channel_name.empty() || channel_name[0] != kStartChar || channel_name.length() > kNameMaxLength) {
 		event.set_error_status(ErrorStatus::ERR_NOSUCHCHANNEL);
 		return ;
 	}
-	for (std::size_t i = 0; i < params.size(); i++) {
-		if (kMustNotContain.find(params[i]) != std::string::npos) {
+	for (std::size_t i = 0; i < kMustNotContain.length(); i++) {
+		if (channel_name.find(kMustNotContain[i]) != std::string::npos) {
 			event.set_error_status(ErrorStatus::ERR_NOSUCHCHANNEL);
 			return ;
 		}

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -95,11 +95,18 @@ void Database::CheckCommandAndParams(Event& event) const {
 	}
 }
 
+static bool IsIgnoringErrorOnJoin(const ErrorStatus& status) {
+	return (status == ErrorStatus::ERR_INVITEONLYCHAN
+			|| status == ErrorStatus::ERR_BADCHANNELKEY
+			|| status == ErrorStatus::ERR_CHANNELISFULL);
+}
+
 void Database::AfterCheck(Event& event) const {
 	if (event.get_command() == message::kJoin) {
-		if (!event.HasErrorOccurred() && event.IsChannelEvent()) {
+		if (event.IsChannelEvent()) {
 			const Channel& channel = dynamic_cast<const ChannelEvent&>(event).get_channel();
-			if (channel.ContainsUser(event.get_executer()))
+			if (channel.ContainsUser(event.get_executer())
+					&& (!event.HasErrorOccurred() || IsIgnoringErrorOnJoin(event.get_error_status())))
 				event.set_do_nothing(true);
 		}
 		return ;

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -140,9 +140,11 @@ void Database::CkUserCommand(Event& event) const {
 }
 
 void Database::CkJoinCommand(Event& event) const {
-	(void)event;
-	std::cout << "Check Join called!" << std::endl;
-	utils::PrintStringVector(event.get_command_params());
+	const int kParamsSize = 1;
+
+	if (event.get_command_params().size() < kParamsSize)
+		event.set_error_status(ErrorStatus::ERR_NEEDMOREPARAMS);
+	
 }
 
 void Database::CkInviteCommand(Event& event) const {

--- a/src/error_status.cpp
+++ b/src/error_status.cpp
@@ -1,37 +1,37 @@
 #include "error_status.h"
 
 const ErrorStatus
+	ErrorStatus::ERR_NOSUCHCHANNEL(403, "No such channel"),
+	ErrorStatus::ERR_TOOMANYCHANNELS(405, "You have joined too many channels"),
     ErrorStatus::ERR_NONICKNAMEGIVEN(431, "No nickname given"),
     ErrorStatus::ERR_ERRONEUSNICKNAME(432, "Erroneus nickname"),
     ErrorStatus::ERR_NICKNAMEINUSE(433, "Nickname is already in use"),
     ErrorStatus::ERR_NEEDMOREPARAMS(461, "Not enough parameters."),
     ErrorStatus::ERR_ALREADYREGISTRED(462, "You may not reregister."),
-    ErrorStatus::ERR_PASSWDMISMATCH(464, "Password incorrect")
+    ErrorStatus::ERR_PASSWDMISMATCH(464, "Password incorrect"),
+	ErrorStatus::ERR_CHANNELISFULL(471, "Cannot join channel (+l)"),
+	ErrorStatus::ERR_INVITEONLYCHAN(473, "Cannot join channel (+i)"),
+	ErrorStatus::ERR_BADCHANNELKEY(475, "Cannot join channel (+k)")
     ;
 
 // 呼ばれない
-ErrorStatus::ErrorStatus() : code_(0), message_("")
-{
+ErrorStatus::ErrorStatus() : code_(0), message_("") {
     return ;
 }
 
-ErrorStatus::ErrorStatus(int code, const std::string& message) : code_(code), message_(message)
-{
+ErrorStatus::ErrorStatus(int code, const std::string& message) : code_(code), message_(message) {
     return ;
 }
 
-ErrorStatus::~ErrorStatus()
-{
+ErrorStatus::~ErrorStatus() {
     return ;
 }
 
-const std::string& ErrorStatus::get_error_message() const
-{
+const std::string& ErrorStatus::get_error_message() const {
     return this->message_;
 }
 
-int ErrorStatus::get_error_code() const
-{
+int ErrorStatus::get_error_code() const {
     return this->code_;
 }
 

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -14,6 +14,7 @@ Event::Event(const Event& src)
 		: fd_(src.get_fd()), event_type_(src.get_event_type()), error_status_(src.error_status_), executer_(src.executer_) {
 	this->set_command(src.get_command());
 	this->set_command_params(src.get_command_params());
+	this->set_do_nothing(src.is_do_nothing());
 }
 
 Event::~Event() {
@@ -76,6 +77,14 @@ const User& Event::get_executer() const {
 	if (this->executer_ == NULL)
 		throw Event::NoExecuterException();
 	return *(this->executer_);
+}
+
+void Event::set_do_nothing(bool is_do_nothing) {
+	this->is_do_nothing_ = is_do_nothing;
+}
+
+bool Event::is_do_nothing() const {
+	return this->is_do_nothing_;
 }
 
 Event::NoErrorException::NoErrorException()

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -320,7 +320,7 @@ bool EventHandler::CheckNewChannel(const Event& event) {
 void EventHandler::AddNewChannel(Event*& event_ptr) {
 	const User& op = event_ptr->get_executer();
 	const std::string& name = event_ptr->get_command_params()[0];
-	const Channel channel = this->database_.CreateChannel(op, name);
+	const Channel& channel = this->database_.CreateChannel(op, name);
 	ChannelEvent* channel_event = new ChannelEvent(*event_ptr, channel);
 	delete event_ptr;
 	event_ptr = channel_event;

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -303,6 +303,8 @@ void	EventHandler::Execute(const pollfd& entry, const std::string& msg) {
 
 void EventHandler::ExecuteCommand(Event*& event_ptr) {
 	database_.CheckEvent(event_ptr);
+	if (event_ptr->is_do_nothing())
+		return ;
 	if (EventHandler::CheckNewChannel(*event_ptr))
 		this->AddNewChannel(event_ptr);
 	AddResponseMap(database_.ExecuteEvent(*event_ptr));

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -1,4 +1,5 @@
 #include "event_handler.h"
+#include "message.h"
 #include <errno.h>
 
 const	int	EventHandler::kQueueLimit = 10;

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -1,5 +1,7 @@
 #include "event_handler.h"
 #include "message.h"
+#include "channel.h"
+#include "channel_event.h"
 #include <errno.h>
 
 const	int	EventHandler::kQueueLimit = 10;
@@ -299,10 +301,27 @@ void	EventHandler::Execute(const pollfd& entry, const std::string& msg) {
 		request_map_.insert(std::make_pair(entry.fd, request_buffer));
 }
 
-void EventHandler::ExecuteCommand(Event*& event) {
-	database_.CheckEvent(event);
-	AddResponseMap(database_.ExecuteEvent(*event));
+void EventHandler::ExecuteCommand(Event*& event_ptr) {
+	database_.CheckEvent(event_ptr);
+	if (EventHandler::CheckNewChannel(*event_ptr))
+		this->AddNewChannel(event_ptr);
+	AddResponseMap(database_.ExecuteEvent(*event_ptr));
 	database_.DeleteFinishedElements();
+}
+
+bool EventHandler::CheckNewChannel(const Event& event) {
+	return (!event.HasErrorOccurred()
+			&& event.get_command() == message::Command::kJoin
+			&& !event.IsChannelEvent());
+}
+
+void EventHandler::AddNewChannel(Event*& event_ptr) {
+	const User& op = event_ptr->get_executer();
+	const std::string& name = event_ptr->get_command_params()[0];
+	const Channel channel = this->database_.CreateChannel(op, name);
+	ChannelEvent* channel_event = new ChannelEvent(*event_ptr, channel);
+	delete event_ptr;
+	event_ptr = channel_event;
 }
 
 message::ParseState	EventHandler::Parse(const std::string& buffer, Event &event) {

--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -311,7 +311,7 @@ void EventHandler::ExecuteCommand(Event*& event_ptr) {
 
 bool EventHandler::CheckNewChannel(const Event& event) {
 	return (!event.HasErrorOccurred()
-			&& event.get_command() == message::Command::kJoin
+			&& event.get_command() == message::kJoin
 			&& !event.IsChannelEvent());
 }
 

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -163,7 +163,7 @@ std::string User::GenerateJoinDetailMessage(const Channel& channel) const {
 	ss << 353 << " "
 		<< this->get_nick_name() << " = "
 		<< channel.get_name() << " :"
-		<< channel.GenerateMemberList() << "\r\n";
+		<< channel.GenerateMemberListWithNewUser(*this) << "\r\n";
 	// End of NAMES list
 	ss << 366 << " "
 		<< this->get_nick_name() << " "

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -230,7 +230,7 @@ void User::CkUserCommand(Event& event) const {
 }
 
 void User::CkJoinCommand(Event& event) const {
-	
+	(void)event;
 }
 
 void User::CkInviteCommand(Event& event) const

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -152,11 +152,12 @@ OptionalMessage User::ExJoinCommand(const Event& event) {
 	if (!event.IsChannelEvent())
 		return OptionalMessage::Empty();
 	const Channel& channel = dynamic_cast<const ChannelEvent&>(event).get_channel();
-	// channelに所属しているか
-	// 所属している -> fdが自分 -> 一行目にメンバー、二行目にエンドオブメッセージを出力
-	// 所属している -> 自分でない -> メンバーが入室したことを知らせる
-	// 所属していない -> 何もなし
-	return OptionalMessage::Empty();
+	if (!channel.ContainsUser(*this))
+		return OptionalMessage::Empty();
+	if (event.get_fd() == this->fd_)
+		return OptionalMessage::Create(this->fd_, "めんば\nめっせーじ");
+	else
+		return OptionalMessage::Create(this->fd_, "入ってきたお");
 }
 
 OptionalMessage User::ExInviteCommand(const Event& event){
@@ -226,11 +227,8 @@ void User::CkUserCommand(Event& event) const {
 		event.set_error_status(ErrorStatus::ERR_ALREADYREGISTRED);
 }
 
-void User::CkJoinCommand(Event& event) const
-{
-	(void)event;
-	std::cout << "Check Join called!" << std::endl;
-	utils::PrintStringVector(event.get_command_params());
+void User::CkJoinCommand(Event& event) const {
+	
 }
 
 void User::CkInviteCommand(Event& event) const

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,6 @@
 #include "utils.h"
 
-
-namespace utils{
+namespace utils {
 
 void CheckPort(std::string num_str) {
 	for (int i = 0; i < (int)num_str.length(); i++)
@@ -111,6 +110,12 @@ bool HasNewlines(const std::string& str) {
 	if (find_n_type == std::string::npos && find_r_n_type == std::string::npos)
 		return false;
 	return true;
+}
+
+std::string StrToLower(const std::string& str) {
+	std::string ret;
+	std::transform(str.begin(), str.end(), ret.begin(), ::tolower);
+	return ret;
 }
 
 UtilsException::UtilsException(const std::string& msg) : std::invalid_argument(msg) {};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include <iterator> // for std::back_inserter
 
 namespace utils {
 
@@ -114,7 +115,7 @@ bool HasNewlines(const std::string& str) {
 
 std::string StrToLower(const std::string& str) {
 	std::string ret;
-	std::transform(str.begin(), str.end(), ret.begin(), ::tolower);
+	std::transform(str.begin(), str.end(), std::back_inserter(ret), ::tolower);
 	return ret;
 }
 


### PR DESCRIPTION
JOINコマンドを実装するにあたり、様々な変更を加えました。
JOIN系関数(CkJoin~, ExJoin~)以外の部分での変更は以下の通りです。
・Eventにis_do_nothing変数を追加 (コマンドを実行する(Executeに回す)意味がないことを示す変数。JOINでそれを判定するとき、変数を使用しないと実装できなかったため。)
 -> 認証前で実行しても意味がない場合を判定する文も、現在はEventHandlerに記述していますが、この変数を利用したいです。
・Channelを、オペレーターが複数いても大丈夫なように変更
・Channelのモードの管理方法をmapに変更
・Channelのnicknameによる検索において、一致条件を変更 ([こちら](https://github.com/orgs/IRC-WIR/projects/2/views/1?pane=issue&itemId=85110066)の問題に対応しました)
・EventHandler内に、必要に応じてChannelを生成する関数を作成 ([こちら](https://github.com/orgs/IRC-WIR/projects/2/views/1?pane=issue&itemId=84449896)に対応)
　↑これDatabase内でも良いかも？
・UserにChannelを持たせるよう変更 ([こちら](https://github.com/orgs/IRC-WIR/projects/2/views/1?pane=issue&itemId=85057209)に対応)
・DatabaseのCheck内で、EventConfiguratorをすべて回した後に実行する関数「AfterCheck」の実装
・utilsにStrToLowerや、vectorを継承して新たに「Contains」と「Remove」関数を追加したクラスを実装

makeによるコンパイルは確認済みです。
