### PR TITLE
認証前ではほとんどのコマンドを実行しないよう修正

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -167,6 +167,8 @@ std::vector<std::string> Channel::RequestModeInfo(const User& client) const {
 }
 
 void Channel::CheckCommand(Event*& event) const {
+	if (event->HasErrorOccurred())
+		return ;
 	const Command& command = event->get_command();
 
 	if (command == Command::kPass)

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -28,14 +28,9 @@ const Channel& Database::CreateChannel(const User& op, const std::string& name) 
 
 void Database::CheckEvent(Event*& event) const {
 	Database::CheckCommandAndParams(*event);
-	if (event->HasErrorOccurred())
-		return ;
 	std::size_t vector_length = check_element_.size();
-	for (std::size_t i = 0; i < vector_length; i++) {
+	for (std::size_t i = 0; i < vector_length; i++)
 		check_element_[i] -> CheckCommand(event);
-		if (event->HasErrorOccurred())
-			return ;
-	}
 	if (event->HasErrorOccurred())
 			return ;
 	this->AfterCheck(*event);

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -94,6 +94,17 @@ void Event::set_do_nothing(bool is_do_nothing) {
 }
 
 bool Event::is_do_nothing() const {
+	if (!(this->get_command() == Command::kPass
+			|| this->get_command() == Command::kNick
+			|| this->get_command() == Command::kUser
+			|| this->get_command() == Command::kQuit)) {
+		try {
+			if (!this->get_executer().IsVerified())
+				return true;
+		} catch (const Event::NoExecuterException& e) {
+			std::cerr << e.what() << std::endl;
+		}
+	}
 	return !this->HasErrorOccurred() && this->is_do_nothing_;
 }
 

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -45,6 +45,8 @@ std::string User::CreateReplyMessage(int code, const std::vector<std::string>& m
 void User::CheckCommand(Event*& event) const {
 	if (event->get_fd() == this->get_fd())
 		event->set_executer(*this);
+	if (event->HasErrorOccurred())
+		return ;
 
 	const Command& command = event->get_command();
 


### PR DESCRIPTION
チェックするために必ずexecuterが設定されていなければならなかったため、即時リターンの仕様を少し変えました。