### PR TITLE
eventにエラーメッセージ生成関数を作成

### DIFF
--- a/includes/channel_event.h
+++ b/includes/channel_event.h
@@ -13,6 +13,7 @@ class ChannelEvent : public Event {
 
 	private:
 		const Channel& channel_;
+		std::string CreateTargetStr(const std::string&) const;
 };
 
 #endif

--- a/includes/event.h
+++ b/includes/event.h
@@ -28,6 +28,7 @@ class Event {
 		bool is_do_nothing(void) const;
 		void IncreaseUserCount(void);
 		int get_user_count(void) const;
+		std::string CreateErrorMessage(const User&, const std::string&) const;
 
 		class NoErrorException : public std::runtime_error {
 			public:
@@ -52,6 +53,7 @@ class Event {
 
 	protected:
 		Event(const Event&);
+		virtual std::string CreateTargetStr(const std::string&) const;
 
 	private:
 		const int	fd_;

--- a/includes/user.h
+++ b/includes/user.h
@@ -47,7 +47,6 @@ class User : public EventListener, public EventConfigurator {
 
 		bool IsTarget(const std::string& target, const Event& event) const;
 		std::string CreateMessage(const User& from, const std::string& target, const Command& cmd, const std::vector<std::string>& params) const;
-		std::string CreateErrorMessage(const std::string& target, const ErrorStatus& error_status) const;
 		std::string CreateTopicRplMessage(const Channel& channel) const;
 		std::string CreateJoinDetailMessage(const Channel&) const;
 		std::string CreateInviteDetailMessage(void) const;

--- a/src/channel_event.cpp
+++ b/src/channel_event.cpp
@@ -16,3 +16,22 @@ const Channel& ChannelEvent::get_channel() const {
 bool ChannelEvent::IsChannelEvent() const {
 	return true;
 }
+
+std::string ChannelEvent::CreateTargetStr(const std::string& target) const {
+	const ErrorStatus& error_status = this->get_error_status();
+
+	if (error_status == ErrorStatus::ERR_CANNOTSENDTOCHAN
+			|| error_status == ErrorStatus::ERR_TOOMANYCHANNELS
+			|| error_status == ErrorStatus::ERR_NOTONCHANNEL
+			|| error_status == ErrorStatus::ERR_KEYSET
+			|| error_status == ErrorStatus::ERR_CHANNELISFULL
+			|| error_status == ErrorStatus::ERR_INVITEONLYCHAN
+			|| error_status == ErrorStatus::ERR_BADCHANNELKEY
+			|| error_status == ErrorStatus::ERR_CHANOPRIVSNEEDED)
+		return (this->get_channel().get_name() + " ");
+	else if (error_status == ErrorStatus::ERR_USERNOTINCHANNEL
+			|| error_status == ErrorStatus::ERR_USERONCHANNEL)
+		return (target + " " + this->get_channel().get_name() + " ");
+	else
+		return Event::CreateTargetStr(target);
+}

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -106,30 +106,6 @@ OptionalMessage User::ExecuteCommand(const Event& event) {
 
 }
 
-std::string User::CreateErrorMessage(const std::string& target, const ErrorStatus& error_status) const {
-	std::stringstream ss;
-	//add hostname
-	ss << ":";
-	ss << utils::kHostName;
-	ss << " ";
-	//add error no
-	ss << utils::FillZero(error_status.get_code(), 3);
-	ss << " ";
-	//add nick name
-	ss << (nick_name_.empty()? "*" : nick_name_) ;
-	ss << " ";
-	//add target
-	if (!target.empty()) {
-		ss << target;
-		ss << " ";
-	}
-	//add Error Message
-	ss << ":";
-	ss << error_status.get_message();
-	ss << utils::kNewLine;
-	return ss.str();
-}
-
 std::string User::CreateMessage(const User& from, const std::string& target, const Command& cmd, const std::vector<std::string>& params) const {
 	std::stringstream ss;
 	ss << ":";


### PR DESCRIPTION
ブランチ名は無視してください。
user.cppは変更を反映していません。
この関数の意図を汲んで、皆さんそれぞれの関数を修正してほしいです。
あと、対象のchannelが見つかったうえで設定できるエラーの時でも、必ずChannelEventにするよう、設計を変更してください。
(思い当たるのは、KICK)
皆さんを信じて、いったんここで作業をやめて校舎に向かいます！
さらば！